### PR TITLE
feat: v2.0.0 — AI agent schema discovery, auto-pagination, enhanced t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.0.0] - 2026-05-23
+
+### Added
+- **Describe Schema Operation** — Fetch full database schema (tables, columns, types, metadata) in structured JSON or concise text format optimized for AI agent context windows
+- **Auto-Pagination for Execute Query** — Automatically page through large result sets using LIMIT/OFFSET with configurable page size and safety limits (max total rows)
+- **AI Agent Enhancements** — Improved operation descriptions for better AI tool discovery; agents can call Describe Schema to discover tables, then construct queries autonomously
+- **Sample Data in Schema** — Optional sample values per table to help AI agents understand data patterns
+- **Schema Text Summary** — `formatSchemaForAgent()` renders compact, readable schema descriptions with row counts, column flags (PK, sort, partition), and table engine info
+- Node version bumped to [1, 2, 3]
+
+### Changed
+- Enhanced Execute Query description to guide AI agents toward schema discovery
+- Added 21 new unit tests for schema formatting helpers (159 total)
+
 ## [1.4.0] - 2026-03-19
 
 ### Security

--- a/nodes/ClickHouse/ClickHouse.helpers.ts
+++ b/nodes/ClickHouse/ClickHouse.helpers.ts
@@ -82,6 +82,30 @@ export interface QueryStats {
 	elapsed_ns: string;
 }
 
+export interface SchemaColumn {
+	name: string;
+	type: string;
+	default_kind?: string;
+	default_expression?: string;
+	comment?: string;
+	is_in_sorting_key?: number;
+	is_in_primary_key?: number;
+	is_in_partition_key?: number;
+}
+
+export interface SchemaTable {
+	name: string;
+	engine: string;
+	total_rows: number | string;
+	total_bytes: number | string;
+	sorting_key?: string;
+	partition_key?: string;
+	primary_key?: string;
+	comment?: string;
+	columns: SchemaColumn[];
+	sampleData?: Record<string, unknown>[];
+}
+
 /**
  * Validates a ClickHouse identifier (database name, table name).
  * Throws if the identifier contains invalid characters that could enable injection.
@@ -352,6 +376,73 @@ export function buildCreateTableDDL(params: {
 	}
 
 	return ddl;
+}
+
+// ============================================================================
+// SCHEMA FORMATTING (for AI agent tool descriptions)
+// ============================================================================
+
+export function formatRowCount(count: number | string): string {
+	const n = typeof count === 'string' ? parseInt(count, 10) : count;
+	if (isNaN(n) || n === 0) return '0';
+	if (n < 1000) return String(n);
+	if (n < 1_000_000) return `${(n / 1000).toFixed(1)}K`;
+	if (n < 1_000_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	return `${(n / 1_000_000_000).toFixed(1)}B`;
+}
+
+export function formatBytes(bytes: number | string): string {
+	const n = typeof bytes === 'string' ? parseInt(bytes, 10) : bytes;
+	if (isNaN(n) || n === 0) return '0B';
+	if (n < 1024) return `${n}B`;
+	if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+	if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)}MB`;
+	return `${(n / (1024 * 1024 * 1024)).toFixed(1)}GB`;
+}
+
+export function formatSchemaForAgent(database: string, tables: SchemaTable[]): string {
+	const lines: string[] = [
+		`Database: ${database} (${tables.length} table${tables.length !== 1 ? 's' : ''})`,
+		'',
+	];
+
+	for (const table of tables) {
+		const rowCount = formatRowCount(table.total_rows);
+		const size = formatBytes(table.total_bytes);
+
+		let tableHeader = `Table: ${table.name} [${table.engine}, ${rowCount} rows, ${size}]`;
+		if (table.sorting_key) {
+			tableHeader += ` ORDER BY (${table.sorting_key})`;
+		}
+		if (table.comment) {
+			tableHeader += ` — ${table.comment}`;
+		}
+		lines.push(tableHeader);
+
+		for (const col of table.columns) {
+			let colLine = `  ${col.name}: ${col.type}`;
+			const flags: string[] = [];
+			if (col.is_in_primary_key) flags.push('PK');
+			if (col.is_in_sorting_key) flags.push('sort');
+			if (col.is_in_partition_key) flags.push('partition');
+			if (col.default_kind && col.default_kind !== '') {
+				flags.push(`default=${col.default_expression}`);
+			}
+			if (flags.length > 0) colLine += ` [${flags.join(', ')}]`;
+			if (col.comment) colLine += ` — ${col.comment}`;
+			lines.push(colLine);
+		}
+		lines.push('');
+	}
+
+	if (tables.length > 0) {
+		const summaryParts = tables.map(
+			(t) => `${t.name} (${formatRowCount(t.total_rows)} rows)`,
+		);
+		lines.push(`Summary: ${summaryParts.join(', ')}`);
+	}
+
+	return lines.join('\n').trim();
 }
 
 // ============================================================================

--- a/nodes/ClickHouse/ClickHouse.node.ts
+++ b/nodes/ClickHouse/ClickHouse.node.ts
@@ -19,6 +19,7 @@ import { listDatabasesFields } from './descriptions/listDatabases.description';
 import { listTablesFields } from './descriptions/listTables.description';
 import { getTableInfoFields } from './descriptions/getTableInfo.description';
 import { createTableFields } from './descriptions/createTable.description';
+import { describeSchemaFields } from './descriptions/describeSchema.description';
 import {
 	buildBaseUrl,
 	buildAuthHeader,
@@ -34,8 +35,9 @@ import {
 	validateWhereClause,
 	validateColumnUpdates,
 	escapeStringValue,
+	formatSchemaForAgent,
 } from './ClickHouse.helpers';
-import type { ClickHouseCredentials, ColumnMapping, QueryParam } from './ClickHouse.helpers';
+import type { ClickHouseCredentials, ColumnMapping, QueryParam, SchemaColumn, SchemaTable } from './ClickHouse.helpers';
 
 export class ClickHouse implements INodeType {
 	description: INodeTypeDescription = {
@@ -43,9 +45,10 @@ export class ClickHouse implements INodeType {
 		name: 'clickHouse',
 		icon: 'file:clickhouse.svg',
 		group: ['transform'],
-		version: [1, 2],
+		version: [1, 2, 3],
 		subtitle: '={{ $parameter["operation"] }}',
-		description: 'Query, insert, update, delete, and manage ClickHouse tables from n8n workflows',
+		description:
+			'Query, insert, update, delete, and manage ClickHouse tables. Supports AI agent tool use with schema discovery, auto-pagination for large results, and parameterized queries.',
 		defaults: {
 			name: 'ClickHouse',
 		},
@@ -78,9 +81,17 @@ export class ClickHouse implements INodeType {
 						action: 'Delete rows from a table',
 					},
 					{
+						name: 'Describe Schema',
+						value: 'describeSchema',
+						description:
+							'Get full database schema with tables, columns, types, and metadata. Ideal for AI agents to discover available data before querying.',
+						action: 'Describe the database schema',
+					},
+					{
 						name: 'Execute Query',
 						value: 'executeQuery',
-						description: 'Run a SELECT query and return the results',
+						description:
+							'Run a SELECT query with optional parameterized values, pagination, and query stats. Use Describe Schema first to discover tables and columns.',
 						action: 'Execute a query',
 					},
 					{
@@ -141,6 +152,7 @@ export class ClickHouse implements INodeType {
 			...listTablesFields,
 			...getTableInfoFields,
 			...createTableFields,
+			...describeSchemaFields,
 		],
 	};
 
@@ -258,6 +270,9 @@ export class ClickHouse implements INodeType {
 						includeStats?: boolean;
 						queryId?: string;
 						querySettings?: string;
+						autoPaginate?: boolean;
+						pageSize?: number;
+						maxRows?: number;
 					};
 
 					const queryParametersData = this.getNodeParameter(
@@ -269,81 +284,134 @@ export class ClickHouse implements INodeType {
 					};
 					const queryParams: QueryParam[] = queryParametersData.params || [];
 
-					// Append LIMIT if not already present
-					const limit = Math.max(0, Math.floor(options.limit ?? 100));
-					if (limit > 0 && !/\blimit\b/i.test(query)) {
-						query = `${query.replace(/;\s*$/, '')} LIMIT ${limit}`;
-					}
-
-					// Append OFFSET if not already present
-					const offset = Math.max(0, Math.floor(options.offset ?? 0));
-					if (offset > 0 && !/\boffset\b/i.test(query)) {
-						query = `${query.replace(/;\s*$/, '')} OFFSET ${offset}`;
-					}
-
-					// Add FORMAT JSONEachRow
-					query = `${query.replace(/;\s*$/, '')} FORMAT JSONEachRow`;
-
 					const urlParams = buildUrlParams(
 						credentials.database,
 						options.querySettings,
 						queryParams,
 					);
 
-					// Build URL with optional query_id
-					let url = `${baseUrl}/?${urlParams}`;
-					if (options.queryId) {
-						url += `&query_id=${encodeURIComponent(options.queryId)}`;
-					}
+					if (options.autoPaginate) {
+						// Auto-pagination: fetch all pages using LIMIT/OFFSET
+						const pageSize = Math.max(100, Math.min(Math.floor(options.pageSize ?? 10000), 100_000));
+						const maxRows = Math.max(1, Math.floor(options.maxRows ?? 100_000));
+						let currentOffset = 0;
+						let totalFetched = 0;
+						const baseQuery = query.replace(/;\s*$/, '');
 
-					const rawResponse = await this.helpers.httpRequest({
-						method: 'POST',
-						url,
-						headers: {
-							Authorization: authHeader,
-							'Content-Type': 'text/plain',
-						},
-						body: query,
-						returnFullResponse: options.includeStats ? true : false,
-					});
+						while (totalFetched < maxRows) {
+							const currentLimit = Math.min(pageSize, maxRows - totalFetched);
+							const pageQuery = `${baseQuery} LIMIT ${currentLimit} OFFSET ${currentOffset} FORMAT JSONEachRow`;
 
-					let responseBody: string;
-					let stats: Record<string, unknown> | null = null;
+							let url = `${baseUrl}/?${urlParams}`;
+							if (options.queryId) {
+								url += `&query_id=${encodeURIComponent(options.queryId)}`;
+							}
 
-					if (options.includeStats && rawResponse && typeof rawResponse === 'object') {
-						const fullResp = rawResponse as {
-							body: string;
-							headers: Record<string, string>;
-						};
-						responseBody = fullResp.body;
-						stats = parseQueryStats(
-							fullResp.headers?.['x-clickhouse-summary'],
-						) as unknown as Record<string, unknown>;
+							const rawResponse = await this.helpers.httpRequest({
+								method: 'POST',
+								url,
+								headers: {
+									Authorization: authHeader,
+									'Content-Type': 'text/plain',
+								},
+								body: pageQuery,
+								returnFullResponse: false,
+							});
+
+							const rows = parseClickHouseResponse(rawResponse as string);
+
+							for (const row of rows) {
+								returnData.push({
+									json: row as IDataObject,
+									pairedItem: { item: i },
+								});
+							}
+
+							totalFetched += rows.length;
+							currentOffset += rows.length;
+
+							if (rows.length < currentLimit) {
+								break;
+							}
+						}
+
+						if (totalFetched === 0 && options.queryId) {
+							returnData.push({
+								json: { _queryId: options.queryId, _totalRows: 0 },
+								pairedItem: { item: i },
+							});
+						}
 					} else {
-						responseBody = rawResponse as string;
-					}
-
-					const rows = parseClickHouseResponse(responseBody);
-					for (const row of rows) {
-						const json: IDataObject = { ...(row as IDataObject) };
-						if (stats) {
-							json._stats = stats as IDataObject;
+						// Single-page query (existing behavior)
+						// Append LIMIT if not already present
+						const limit = Math.max(0, Math.floor(options.limit ?? 100));
+						if (limit > 0 && !/\blimit\b/i.test(query)) {
+							query = `${query.replace(/;\s*$/, '')} LIMIT ${limit}`;
 						}
+
+						// Append OFFSET if not already present
+						const offset = Math.max(0, Math.floor(options.offset ?? 0));
+						if (offset > 0 && !/\boffset\b/i.test(query)) {
+							query = `${query.replace(/;\s*$/, '')} OFFSET ${offset}`;
+						}
+
+						// Add FORMAT JSONEachRow
+						query = `${query.replace(/;\s*$/, '')} FORMAT JSONEachRow`;
+
+						let url = `${baseUrl}/?${urlParams}`;
 						if (options.queryId) {
-							json._queryId = options.queryId;
+							url += `&query_id=${encodeURIComponent(options.queryId)}`;
 						}
-						returnData.push({
-							json,
-							pairedItem: { item: i },
-						});
-					}
 
-					// If no rows but stats requested, still output stats
-					if (rows.length === 0 && (stats || options.queryId)) {
-						const json: IDataObject = {};
-						if (stats) json._stats = stats as IDataObject;
-						if (options.queryId) json._queryId = options.queryId;
-						returnData.push({ json, pairedItem: { item: i } });
+						const rawResponse = await this.helpers.httpRequest({
+							method: 'POST',
+							url,
+							headers: {
+								Authorization: authHeader,
+								'Content-Type': 'text/plain',
+							},
+							body: query,
+							returnFullResponse: options.includeStats ? true : false,
+						});
+
+						let responseBody: string;
+						let stats: Record<string, unknown> | null = null;
+
+						if (options.includeStats && rawResponse && typeof rawResponse === 'object') {
+							const fullResp = rawResponse as {
+								body: string;
+								headers: Record<string, string>;
+							};
+							responseBody = fullResp.body;
+							stats = parseQueryStats(
+								fullResp.headers?.['x-clickhouse-summary'],
+							) as unknown as Record<string, unknown>;
+						} else {
+							responseBody = rawResponse as string;
+						}
+
+						const rows = parseClickHouseResponse(responseBody);
+						for (const row of rows) {
+							const json: IDataObject = { ...(row as IDataObject) };
+							if (stats) {
+								json._stats = stats as IDataObject;
+							}
+							if (options.queryId) {
+								json._queryId = options.queryId;
+							}
+							returnData.push({
+								json,
+								pairedItem: { item: i },
+							});
+						}
+
+						// If no rows but stats requested, still output stats
+						if (rows.length === 0 && (stats || options.queryId)) {
+							const json: IDataObject = {};
+							if (stats) json._stats = stats as IDataObject;
+							if (options.queryId) json._queryId = options.queryId;
+							returnData.push({ json, pairedItem: { item: i } });
+						}
 					}
 				} catch (error) {
 					const chError = extractClickHouseError(error);
@@ -1001,6 +1069,148 @@ export class ClickHouse implements INodeType {
 					},
 					pairedItem: { item: 0 },
 				});
+			} catch (error) {
+				const chError = extractClickHouseError(error);
+				if (this.continueOnFail()) {
+					returnData.push({
+						json: { error: chError },
+						pairedItem: { item: 0 },
+					});
+				} else {
+					throw new NodeOperationError(this.getNode(), chError, { itemIndex: 0 });
+				}
+			}
+
+			// ── Describe Schema ───────────────────────────────────────────
+		} else if (operation === 'describeSchema') {
+			try {
+				const options = this.getNodeParameter('options', 0, {}) as {
+					database?: string;
+					tablePattern?: string;
+					includeSamples?: boolean;
+					sampleSize?: number;
+					outputFormat?: string;
+				};
+
+				const database = options.database || credentials.database;
+				const outputFormat = options.outputFormat || 'both';
+				const urlParams = buildUrlParams(credentials.database);
+
+				let tablesQuery = `SELECT name, engine, total_rows, total_bytes, partition_key, sorting_key, primary_key, comment FROM system.tables WHERE database = '${database.replace(/'/g, "\\'")}'`;
+				if (options.tablePattern) {
+					tablesQuery += ` AND name LIKE '${options.tablePattern.replace(/'/g, "\\'")}'`;
+				}
+				tablesQuery += ` AND name NOT LIKE '.%' ORDER BY name FORMAT JSONEachRow`;
+
+				const tablesResponse = (await this.helpers.httpRequest({
+					method: 'POST',
+					url: `${baseUrl}/?${urlParams}`,
+					headers: {
+						Authorization: authHeader,
+						'Content-Type': 'text/plain',
+					},
+					body: tablesQuery,
+					returnFullResponse: false,
+				})) as string;
+
+				const tableRows = parseClickHouseResponse(tablesResponse);
+
+				let columnsQuery = `SELECT table, name, type, default_kind, default_expression, comment, is_in_partition_key, is_in_sorting_key, is_in_primary_key FROM system.columns WHERE database = '${database.replace(/'/g, "\\'")}'`;
+				if (options.tablePattern) {
+					columnsQuery += ` AND table LIKE '${options.tablePattern.replace(/'/g, "\\'")}'`;
+				}
+				columnsQuery += ` ORDER BY table, position FORMAT JSONEachRow`;
+
+				const columnsResponse = (await this.helpers.httpRequest({
+					method: 'POST',
+					url: `${baseUrl}/?${urlParams}`,
+					headers: {
+						Authorization: authHeader,
+						'Content-Type': 'text/plain',
+					},
+					body: columnsQuery,
+					returnFullResponse: false,
+				})) as string;
+
+				const columnRows = parseClickHouseResponse(columnsResponse);
+
+				const columnsByTable = new Map<string, SchemaColumn[]>();
+				for (const col of columnRows) {
+					const tableName = col.table as string;
+					if (!columnsByTable.has(tableName)) {
+						columnsByTable.set(tableName, []);
+					}
+					columnsByTable.get(tableName)!.push({
+						name: col.name as string,
+						type: col.type as string,
+						default_kind: col.default_kind as string,
+						default_expression: col.default_expression as string,
+						comment: col.comment as string,
+						is_in_sorting_key: col.is_in_sorting_key as number,
+						is_in_primary_key: col.is_in_primary_key as number,
+						is_in_partition_key: col.is_in_partition_key as number,
+					});
+				}
+
+				const schemaTables: SchemaTable[] = tableRows.map((t) => ({
+					name: t.name as string,
+					engine: t.engine as string,
+					total_rows: t.total_rows as number,
+					total_bytes: t.total_bytes as number,
+					sorting_key: t.sorting_key as string,
+					partition_key: t.partition_key as string,
+					primary_key: t.primary_key as string,
+					comment: t.comment as string,
+					columns: columnsByTable.get(t.name as string) || [],
+				}));
+
+				if (options.includeSamples) {
+					const sampleSize = Math.min(Math.max(1, options.sampleSize ?? 3), 10);
+					for (const table of schemaTables) {
+						try {
+							const sampleQuery = `SELECT * FROM \`${table.name}\` LIMIT ${sampleSize} FORMAT JSONEachRow`;
+							const sampleResponse = (await this.helpers.httpRequest({
+								method: 'POST',
+								url: `${baseUrl}/?${urlParams}`,
+								headers: {
+									Authorization: authHeader,
+									'Content-Type': 'text/plain',
+								},
+								body: sampleQuery,
+								returnFullResponse: false,
+							})) as string;
+							table.sampleData = parseClickHouseResponse(sampleResponse);
+						} catch {
+							// Skip tables we can't read
+						}
+					}
+				}
+
+				if (outputFormat === 'summary') {
+					const summary = formatSchemaForAgent(database, schemaTables);
+					returnData.push({
+						json: { database, schema: summary } as IDataObject,
+						pairedItem: { item: 0 },
+					});
+				} else if (outputFormat === 'both') {
+					const summary = formatSchemaForAgent(database, schemaTables);
+					returnData.push({
+						json: {
+							database,
+							tables: schemaTables as unknown as IDataObject[],
+							summary,
+						} as IDataObject,
+						pairedItem: { item: 0 },
+					});
+				} else {
+					returnData.push({
+						json: {
+							database,
+							tables: schemaTables as unknown as IDataObject[],
+						} as IDataObject,
+						pairedItem: { item: 0 },
+					});
+				}
 			} catch (error) {
 				const chError = extractClickHouseError(error);
 				if (this.continueOnFail()) {

--- a/nodes/ClickHouse/descriptions/describeSchema.description.ts
+++ b/nodes/ClickHouse/descriptions/describeSchema.description.ts
@@ -1,0 +1,83 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+export const describeSchemaFields: INodeProperties[] = [
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		displayOptions: {
+			show: {
+				operation: ['describeSchema'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Database Name or ID',
+				name: 'database',
+				type: 'options',
+				default: '',
+				placeholder: 'my_database',
+				description:
+					'Override the database from credentials. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				typeOptions: {
+					loadOptionsMethod: 'getDatabases',
+				},
+			},
+			{
+				displayName: 'Include Sample Values',
+				name: 'includeSamples',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether to include sample values per table to help AI agents understand the data',
+			},
+			{
+				displayName: 'Output Format',
+				name: 'outputFormat',
+				type: 'options',
+				default: 'both',
+				options: [
+					{
+						name: 'Both',
+						value: 'both',
+						description:
+							'Returns both structured JSON and a concise text summary for AI agents',
+					},
+					{
+						name: 'Structured JSON',
+						value: 'structured',
+						description: 'Full JSON with tables, columns, and metadata',
+					},
+					{
+						name: 'Text Summary',
+						value: 'summary',
+						description:
+							'Concise text description optimized for AI agent context windows',
+					},
+				],
+				description: 'How to format the schema output',
+			},
+			{
+				displayName: 'Sample Size',
+				name: 'sampleSize',
+				type: 'number',
+				default: 3,
+				description: 'Number of sample rows to fetch per table when Include Sample Values is enabled',
+				typeOptions: {
+					minValue: 1,
+					maxValue: 10,
+				},
+			},
+			{
+				displayName: 'Table Pattern',
+				name: 'tablePattern',
+				type: 'string',
+				default: '',
+				placeholder: '%events%',
+				description: 'Filter table names using a SQL LIKE pattern',
+			},
+		],
+	},
+];

--- a/nodes/ClickHouse/descriptions/query.description.ts
+++ b/nodes/ClickHouse/descriptions/query.description.ts
@@ -95,6 +95,36 @@ export const queryFields: INodeProperties[] = [
 				},
 			},
 			{
+				displayName: 'Auto-Paginate',
+				name: 'autoPaginate',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether to automatically fetch all result pages using LIMIT/OFFSET. Overrides manual Limit and Offset settings.',
+			},
+			{
+				displayName: 'Max Total Rows',
+				name: 'maxRows',
+				type: 'number',
+				default: 100000,
+				description:
+					'Maximum total rows to fetch across all pages. Prevents runaway queries on large tables.',
+				typeOptions: {
+					minValue: 1,
+				},
+			},
+			{
+				displayName: 'Page Size',
+				name: 'pageSize',
+				type: 'number',
+				default: 10000,
+				description: 'Number of rows to fetch per HTTP request when auto-paginating',
+				typeOptions: {
+					minValue: 100,
+					maxValue: 100000,
+				},
+			},
+			{
 				displayName: 'Include Query Stats',
 				name: 'includeStats',
 				type: 'boolean',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-clickhouse-db",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-clickhouse-db",
-      "version": "1.4.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-clickhouse-db",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "n8n community node for ClickHouse — full CRUD, schema management, polling triggers, and AI agent tool support for ClickHouse and ClickHouse Cloud",
   "keywords": [
     "n8n-community-node-package",

--- a/tests/ClickHouse.helpers.test.ts
+++ b/tests/ClickHouse.helpers.test.ts
@@ -16,8 +16,11 @@ import {
 	validateColumnUpdates,
 	escapeStringValue,
 	buildSafeSetClause,
+	formatRowCount,
+	formatBytes,
+	formatSchemaForAgent,
 } from '../nodes/ClickHouse/ClickHouse.helpers';
-import type { ClickHouseCredentials } from '../nodes/ClickHouse/ClickHouse.helpers';
+import type { ClickHouseCredentials, SchemaTable } from '../nodes/ClickHouse/ClickHouse.helpers';
 
 const creds: ClickHouseCredentials = {
 	host: 'localhost',
@@ -811,6 +814,208 @@ describe('SQL Injection Penetration Tests', () => {
 			it(`rejects: "${payload.slice(0, 40)}..."`, () => {
 				expect(() => validateSetExpression(payload)).toThrow();
 			});
+		});
+	});
+
+	// ========================================================================
+	// Schema Formatting (AI Agent Support)
+	// ========================================================================
+
+	describe('formatRowCount', () => {
+		it('returns "0" for zero', () => {
+			expect(formatRowCount(0)).toBe('0');
+		});
+
+		it('returns exact number below 1000', () => {
+			expect(formatRowCount(500)).toBe('500');
+			expect(formatRowCount(1)).toBe('1');
+			expect(formatRowCount(999)).toBe('999');
+		});
+
+		it('formats thousands', () => {
+			expect(formatRowCount(1000)).toBe('1.0K');
+			expect(formatRowCount(1500)).toBe('1.5K');
+			expect(formatRowCount(999_999)).toBe('1000.0K');
+		});
+
+		it('formats millions', () => {
+			expect(formatRowCount(1_000_000)).toBe('1.0M');
+			expect(formatRowCount(2_500_000)).toBe('2.5M');
+		});
+
+		it('formats billions', () => {
+			expect(formatRowCount(1_000_000_000)).toBe('1.0B');
+			expect(formatRowCount(1_500_000_000)).toBe('1.5B');
+		});
+
+		it('handles string input', () => {
+			expect(formatRowCount('5000')).toBe('5.0K');
+			expect(formatRowCount('0')).toBe('0');
+		});
+
+		it('returns "0" for NaN', () => {
+			expect(formatRowCount('abc')).toBe('0');
+		});
+	});
+
+	describe('formatBytes', () => {
+		it('returns "0B" for zero', () => {
+			expect(formatBytes(0)).toBe('0B');
+		});
+
+		it('returns bytes below 1024', () => {
+			expect(formatBytes(500)).toBe('500B');
+			expect(formatBytes(1)).toBe('1B');
+		});
+
+		it('formats kilobytes', () => {
+			expect(formatBytes(1024)).toBe('1.0KB');
+			expect(formatBytes(1536)).toBe('1.5KB');
+		});
+
+		it('formats megabytes', () => {
+			expect(formatBytes(1024 * 1024)).toBe('1.0MB');
+			expect(formatBytes(5 * 1024 * 1024)).toBe('5.0MB');
+		});
+
+		it('formats gigabytes', () => {
+			expect(formatBytes(1024 * 1024 * 1024)).toBe('1.0GB');
+			expect(formatBytes(2.5 * 1024 * 1024 * 1024)).toBe('2.5GB');
+		});
+
+		it('handles string input', () => {
+			expect(formatBytes('2048')).toBe('2.0KB');
+		});
+
+		it('returns "0B" for NaN', () => {
+			expect(formatBytes('abc')).toBe('0B');
+		});
+	});
+
+	describe('formatSchemaForAgent', () => {
+		it('formats empty database', () => {
+			const result = formatSchemaForAgent('test_db', []);
+			expect(result).toContain('Database: test_db (0 tables)');
+		});
+
+		it('uses singular "table" for one table', () => {
+			const tables: SchemaTable[] = [
+				{
+					name: 'events',
+					engine: 'MergeTree',
+					total_rows: 100,
+					total_bytes: 1024,
+					columns: [{ name: 'id', type: 'UInt64' }],
+				},
+			];
+			const result = formatSchemaForAgent('db', tables);
+			expect(result).toContain('(1 table)');
+			expect(result).not.toContain('(1 tables)');
+		});
+
+		it('formats database with tables and columns', () => {
+			const tables: SchemaTable[] = [
+				{
+					name: 'events',
+					engine: 'MergeTree',
+					total_rows: 1_000_000,
+					total_bytes: 52_428_800,
+					sorting_key: 'event_time',
+					columns: [
+						{ name: 'event_time', type: 'DateTime', is_in_sorting_key: 1 },
+						{ name: 'user_id', type: 'UInt64' },
+						{ name: 'event_type', type: 'String', comment: 'Type of event' },
+					],
+				},
+			];
+			const result = formatSchemaForAgent('analytics', tables);
+			expect(result).toContain('Database: analytics (1 table)');
+			expect(result).toContain('Table: events [MergeTree, 1.0M rows, 50.0MB]');
+			expect(result).toContain('ORDER BY (event_time)');
+			expect(result).toContain('event_time: DateTime [sort]');
+			expect(result).toContain('user_id: UInt64');
+			expect(result).toContain('event_type: String — Type of event');
+			expect(result).toContain('Summary: events (1.0M rows)');
+		});
+
+		it('includes column flags for primary key and partition key', () => {
+			const tables: SchemaTable[] = [
+				{
+					name: 'logs',
+					engine: 'MergeTree',
+					total_rows: 500,
+					total_bytes: 2048,
+					columns: [
+						{
+							name: 'ts',
+							type: 'DateTime',
+							is_in_primary_key: 1,
+							is_in_sorting_key: 1,
+							is_in_partition_key: 1,
+						},
+					],
+				},
+			];
+			const result = formatSchemaForAgent('db', tables);
+			expect(result).toContain('ts: DateTime [PK, sort, partition]');
+		});
+
+		it('includes default expression flags', () => {
+			const tables: SchemaTable[] = [
+				{
+					name: 'users',
+					engine: 'MergeTree',
+					total_rows: 0,
+					total_bytes: 0,
+					columns: [
+						{
+							name: 'created_at',
+							type: 'DateTime',
+							default_kind: 'DEFAULT',
+							default_expression: 'now()',
+						},
+					],
+				},
+			];
+			const result = formatSchemaForAgent('db', tables);
+			expect(result).toContain('created_at: DateTime [default=now()]');
+		});
+
+		it('includes table comment', () => {
+			const tables: SchemaTable[] = [
+				{
+					name: 'metrics',
+					engine: 'MergeTree',
+					total_rows: 1000,
+					total_bytes: 4096,
+					comment: 'Application metrics',
+					columns: [{ name: 'value', type: 'Float64' }],
+				},
+			];
+			const result = formatSchemaForAgent('db', tables);
+			expect(result).toContain('— Application metrics');
+		});
+
+		it('formats multiple tables with summary', () => {
+			const tables: SchemaTable[] = [
+				{
+					name: 'events',
+					engine: 'MergeTree',
+					total_rows: 1_000_000,
+					total_bytes: 0,
+					columns: [{ name: 'id', type: 'UInt64' }],
+				},
+				{
+					name: 'users',
+					engine: 'MergeTree',
+					total_rows: 50_000,
+					total_bytes: 0,
+					columns: [{ name: 'id', type: 'UInt64' }],
+				},
+			];
+			const result = formatSchemaForAgent('db', tables);
+			expect(result).toContain('(2 tables)');
+			expect(result).toContain('Summary: events (1.0M rows), users (50.0K rows)');
 		});
 	});
 });


### PR DESCRIPTION
…ool descriptions

- Add Describe Schema operation: fetches full database schema (tables, columns, types, engine, row counts) with structured JSON and text summary output modes. AI agents call this to discover available data before constructing queries.
- Add auto-pagination to Execute Query: automatically pages through large result sets using LIMIT/OFFSET with configurable page size and max total rows safety limit.
- Enhance operation descriptions for better AI agent tool discovery.
- Add formatRowCount, formatBytes, formatSchemaForAgent helpers with 21 new tests (159 total).
- Bump package version to 2.0.0, node version to [1, 2, 3].

https://claude.ai/code/session_01MXYQjETsQnxh67Ub7bAWJ8