### PR TITLE
fix: replace Buffer.from().toString('base64') with .base64Encode() for n8n sandbox compat

### DIFF
--- a/credentials/ClickHouseApi.credentials.ts
+++ b/credentials/ClickHouseApi.credentials.ts
@@ -120,7 +120,7 @@ export class ClickHouseApi implements ICredentialType {
 		properties: {
 			headers: {
 				Authorization:
-					'={{ $credentials.authMethod === "bearerToken" ? "Bearer " + $credentials.jwtToken : "Basic " + Buffer.from(($credentials.username || "default") + ":" + ($credentials.password || "")).toString("base64") }}',
+					'={{ $credentials.authMethod === "bearerToken" ? "Bearer " + $credentials.jwtToken : "Basic " + (($credentials.username || "default") + ":" + ($credentials.password || "")).base64Encode() }}',
 			},
 		},
 	};


### PR DESCRIPTION
Fixes #10

## Problem

`Buffer` is not available in n8n's expression sandbox (`@n8n/tournament`). When the credential expression evaluates:

```js
"Basic " + Buffer.from(username + ":" + password).toString("base64")
```

it silently throws `Cannot read properties of undefined (reading 'from')`. n8n's `credentials-helper` catches the error and returns `""`, so every request is sent with `Authorization: ""`.

ClickHouse returns HTTP 403:
```
Code: 516. DB::Exception: Invalid authentication: '' HTTP Authorization scheme is not supported.
```

Users see **"Forbidden - perhaps check your credentials?"** even with valid credentials. Affects Basic Auth in versions 1.4.0 and 2.0.1.

## Fix

n8n exposes `.base64Encode()` as a native String extension (wraps `js-base64`, present in all n8n versions that support expression extensions):

```diff
- "Basic " + Buffer.from(($credentials.username || "default") + ":" + ($credentials.password || "")).toString("base64")
+ "Basic " + (($credentials.username || "default") + ":" + ($credentials.password || "")).base64Encode()
```

## Testing

Verified on self-hosted n8n 2.4.5 (Kubernetes):
- Credential Test Connection → ✅ Success
- ClickHouse queries execute correctly